### PR TITLE
Use <Version> instead of <VersionPrefix> in csproj

### DIFF
--- a/Swashbuckle.Servers.Extension/Swashbuckle.Servers.Extension.csproj
+++ b/Swashbuckle.Servers.Extension/Swashbuckle.Servers.Extension.csproj
@@ -14,7 +14,7 @@
 			1.0.2 - Now supports multiple, concatenating invocations
 			1.0.1 - Initial release
 		</PackageReleaseNotes>
-		<VersionPrefix>1.1.0</VersionPrefix>
+		<Version>1.1.0</Version>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Replaced <VersionPrefix> with <Version> in the project file to explicitly set the package version to 1.1.0 and clarify versioning. No other changes were made.